### PR TITLE
fix: set email and name for git user

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
           username: ${{ secrets.SSH_MARIST_USERNAME }}
           passwd: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
 
+      - name: Set email
+        run: git config user.email "zowe-robot@users.noreply.github.com"
+
+      - name: Set name
+        run: git config user.name "Zowe Robot"
+
       - name: Release new version
         run: |
           ./gradlew release -x test -Prelease.useAutomaticVersion=true -Prelease.scope=${{ github.event.inputs.release-scope || env.DEFAULT_SCOPE }} -Pzowe.deploy.username=$ARTIFACTORY_USERNAME -Pzowe.deploy.password=$ARTIFACTORY_PASSWORD -Partifactory_user=$ARTIFACTORY_USERNAME -Partifactory_password=$ARTIFACTORY_PASSWORD


### PR DESCRIPTION
> Task :common-java:preTagCommit FAILED
> Failed to run [git commit -m [Gradle Release plugin] Before tag commit 'v2.0.1'. /home/runner/work/common-java/common-java/gradle.properties] - [][Author identity unknown

This will be probably solved by setting the name and email.