### PR TITLE
Fix memory leak in AT-TLS

### DIFF
--- a/zos-utils/src/main/java/org/zowe/commons/attls/AttlsContext.java
+++ b/zos-utils/src/main/java/org/zowe/commons/attls/AttlsContext.java
@@ -45,7 +45,7 @@ public class AttlsContext {
     /**
      * Control flag to identify if certificate should be fetch in each query call or not
      */
-    private boolean alwaysLoadCertificate;
+    private final boolean alwaysLoadCertificate;
 
     /**
      * FileDescriptior of socket

--- a/zos-utils/zossrc/AttlsContext.c
+++ b/zos-utils/zossrc/AttlsContext.c
@@ -422,7 +422,7 @@ void cleanByteArray(JNIEnv *env, jobject obj, jfieldID arrayField, jboolean setN
  * certificate - if true method will allocate also buffer for reading certificate
  * erase - if true the buffers will be empty - before a new call is a good practice to cleanup buffers
  */
-Context *getContext(JNIEnv *env, jobject obj, jboolean certificate, jboolean erase)
+Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean erase)
 {
     Context *c = (Context*) malloc(sizeof(Context));
 
@@ -448,11 +448,11 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean certificate, jboolean era
     }
 
     // obtain certificate buffer or create new one if needed
-    if (!certificate) {
-        certificate = (*env) -> GetBooleanField(env, obj, always_load_certificate_field);
+    c -> load_certificate = loadCertificate;
+    if (!loadCertificate) {
+        c -> load_certificate = (*env) -> GetBooleanField(env, obj, always_load_certificate_field);
     }
-    c -> load_certificate = certificate;
-    if (certificate) {
+    if (c -> load_certificate) {
         jbyteArray certArray = (*env) -> GetObjectField(env, obj, buffer_certificate_field);
         if (!certArray) {
             certArray = (*env) -> NewByteArray(env, buffer_certificate_size);
@@ -498,7 +498,7 @@ void releaseContext(JNIEnv *env, Context *c)
 
 /**
  * It call ioctl to fetch query or certificate. Query call is done always, the certificate is loaded just if argument
- * certificate is set to true or alwaysLoadCertificate false is set to true.
+ * certificate is set to true or alwaysLoadCertificate is set to true.
  * In case of an error during fetching data IoctlCallException is thrown.
  */
 Context* query(JNIEnv *env, jobject obj, jboolean certificate)

--- a/zos-utils/zossrc/AttlsContext.c
+++ b/zos-utils/zossrc/AttlsContext.c
@@ -46,7 +46,6 @@ const char *JNI_SIGNATURE_PROPERTY_FIPS_140 = "Lorg/zowe/commons/attls/Fips140;"
  */
 const char *JNI_SIGNATURE_METHOD_BYTE_BYTE_PROTOCOL = "(BB)Lorg/zowe/commons/attls/Protocol;";
 const char *JNI_SIGNATURE_METHOD_NONE_BYTE = "()B";
-const char *JNI_SIGNATURE_METHOD_ENUM_BYTE_VOID = "(Ljava/lang/Enum;B)V";
 const char *JNI_SIGNATURE_METHOD_ENUM_BYTE_BYTE_VOID = "(Ljava/lang/Enum;BB)V";
 const char *JNI_SIGNATURE_METHOD_INT_INT_INT_VOID = "(III)V";
 const char *JNI_SIGNATURE_METHOD_NONE_ARRAY_PREFIX = "()[L";
@@ -212,7 +211,6 @@ jmethodID ioctl_call_exception_constructor;
 jclass illegal_argument_exception_clazz;
 jclass unknown_enum_value_exception_clazz;
 jmethodID unknown_enum_value_exception_constructor;
-jmethodID unknown_enum_value_exception_constructor2;
 
 int strnlen(char *txt, int max) {
     if (max < 0) return 0;
@@ -333,7 +331,7 @@ EnumMap* load_enum_map(JNIEnv *env, const char* clazz)
  * Throws UnknownEnumValueException with set values
  */
 void throw_unknown_enum_value(JNIEnv *env, EnumMap* enum_map, unsigned char value) {
-    jobject exception = (*env) -> NewObject(env, unknown_enum_value_exception_clazz, unknown_enum_value_exception_constructor, enum_map -> clazz, (jbyte) value);
+    jobject exception = (*env) -> NewObject(env, unknown_enum_value_exception_clazz, unknown_enum_value_exception_constructor, enum_map -> clazz, (jbyte) value, (jbyte) 0);
     (*env) -> Throw(env, exception);
 }
 
@@ -452,9 +450,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
     if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
     unknown_enum_value_exception_clazz = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_CLASS_UNKNOWN_ENUM_VALUE_EXCEPTION));
     if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    unknown_enum_value_exception_constructor = (*env) -> GetMethodID(env, unknown_enum_value_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_ENUM_BYTE_VOID);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    unknown_enum_value_exception_constructor2 = (*env) -> GetMethodID(env, unknown_enum_value_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_ENUM_BYTE_BYTE_VOID);
+    unknown_enum_value_exception_constructor = (*env) -> GetMethodID(env, unknown_enum_value_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_ENUM_BYTE_BYTE_VOID);
 
     return JNI_VERSION;
 }
@@ -733,7 +729,7 @@ JNIEXPORT jobject JNICALL Java_org_zowe_commons_attls_AttlsContext_getProtocol(J
             (jbyte) c -> ioctl_buffer -> TTLSi_SSL_Protocol.Prot_bytes.Prot_Mod);
         if (!out) {
             // if enum was not fetched, throw exception
-            jobject exception = (*env) -> NewObject(env, unknown_enum_value_exception_clazz, unknown_enum_value_exception_constructor2, enum_protocol_clazz,
+            jobject exception = (*env) -> NewObject(env, unknown_enum_value_exception_clazz, unknown_enum_value_exception_constructor, enum_protocol_clazz,
                 (jbyte) c -> ioctl_buffer -> TTLSi_SSL_Protocol.Prot_bytes.Prot_Ver,
                 (jbyte) c -> ioctl_buffer -> TTLSi_SSL_Protocol.Prot_bytes.Prot_Mod);
             (*env) -> Throw(env, exception);

--- a/zos-utils/zossrc/AttlsContext.c
+++ b/zos-utils/zossrc/AttlsContext.c
@@ -123,6 +123,37 @@ const char *JNI_SIGNATURE_METHOD_BYTE_ARRAY_BYTE_VOID = "([BB)V";
 #define JNI_VERSION JNI_VERSION_1_8
 
 /**
+ * Macros to call a code and immediately check if the exception was thrown during initialization
+ */
+
+#define INIT_FIND_CLASS_REF(field, className)                                               \
+    field = (*env) -> FindClass(env, className);                                            \
+    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;                                  \
+    field = (*env) -> NewGlobalRef(env, field);
+
+#define INIT_GET_STATIC_FIELD_INT_VALUE(field, clazz, fieldName, signature) {               \
+    jfieldID staticField = (*env) -> GetStaticFieldID(env, clazz, fieldName, signature);    \
+    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;                                  \
+    field = (*env) -> GetStaticIntField(env, clazz, staticField);                           \
+}
+
+#define INIT_GET_FIELD_ID(field, clazz, fieldName, signature)                               \
+    field = (*env) -> GetFieldID(env, clazz, fieldName, signature);                         \
+    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+
+#define INIT_GET_METHOD_ID(field, clazz, methodName, signature)                             \
+    field = (*env) -> GetMethodID(env, clazz, methodName, signature);                       \
+    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+
+#define INIT_GET_STATIC_METHOD_ID(field, clazz, methodName, signature)                      \
+    field = (*env) -> GetStaticMethodID(env, clazz, methodName, signature);                 \
+    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+
+#define INIT_LOAD_ENUM_MAP(field, className)                                                \
+    field = load_enum_map(env, className);                                                  \
+    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+
+/**
  * Struct for fast mapping byte values into enumeration. It is possible to use to value which are close to zero.
  * It prepare array and mapping is via index of arrray.
  */
@@ -373,84 +404,50 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved)
     JNIEnv* env = getEnv(vm);
 
     // fetch AtllsContext.class
-    jclass clazz = (*env) -> FindClass(env, JNI_CLASS_ATTLS_CONTEXT);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    attls_context_clazz = (*env) -> NewGlobalRef(env, clazz);
+    INIT_FIND_CLASS_REF(attls_context_clazz, JNI_CLASS_ATTLS_CONTEXT)
 
     // fetch size of certificate length
-    jfieldID buffer_certificate_size_field = (*env) -> GetStaticFieldID(env, clazz, JNI_PROPERTY_BUFFER_CERTIFICATE_LENGTH, JNI_SIGNATURE_PROPERTY_INTEGER);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    buffer_certificate_size = (*env) -> GetStaticIntField(env, clazz, buffer_certificate_size_field);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+    INIT_GET_STATIC_FIELD_INT_VALUE(buffer_certificate_size, attls_context_clazz, JNI_PROPERTY_BUFFER_CERTIFICATE_LENGTH, JNI_SIGNATURE_PROPERTY_INTEGER)
 
     // fetch all fields to properties of AttlsContext
-    always_load_certificate_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_ALWAYS_LOAD_CERTIFICATE, JNI_SIGNATURE_PROPERTY_BOOLEAN);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    id_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_ID, JNI_SIGNATURE_PROPERTY_INTEGER);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    ioctl_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_IOCTL, JNI_SIGNATURE_PROPERTY_BYTE_ARRAY);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    buffer_certificate_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_BUFFER_CERTIFICATE, JNI_SIGNATURE_PROPERTY_BYTE_ARRAY);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    query_loaded_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_QUERY_LOADED, JNI_SIGNATURE_PROPERTY_BOOLEAN);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    certificate_loaded_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_CERTIFICATE_LOADED, JNI_SIGNATURE_PROPERTY_BOOLEAN);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    stat_policy_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_STAT_POLICY_CACHE, JNI_SIGNATURE_PROPERTY_STAT_POLICY);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    stat_conn_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_STAT_CONN_CACHE, JNI_SIGNATURE_PROPERTY_STAT_CONN);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    protocol_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_PROTOCOL_CACHE, JNI_SIGNATURE_PROPERTY_PROTOCOL);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    negotiated_cipher2_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_NEGOTIATED_CIPHER_2_CACHE, JNI_SIGNATURE_PROPERTY_STRING);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    security_type_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_SECURITY_TYPE_CACHE, JNI_SIGNATURE_PROPERTY_SECURITY_TYPE);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    user_id_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_USER_ID_CACHE, JNI_SIGNATURE_PROPERTY_STRING);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    fips140_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_FIPS_140_CACHE, JNI_SIGNATURE_PROPERTY_FIPS_140);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    negotiated_cipher4_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_NEGOTIATED_CIPHER_4_CACHE, JNI_SIGNATURE_PROPERTY_STRING);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    negotiated_key_share_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_NEGOTIATED_KEY_SHARE_CACHE, JNI_SIGNATURE_PROPERTY_STRING);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    certificate_cache_field = (*env) -> GetFieldID(env, clazz, JNI_PROPERTY_CERTIFICATE_CACHE, JNI_SIGNATURE_PROPERTY_BYTE_ARRAY);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+    INIT_GET_FIELD_ID(always_load_certificate_field, attls_context_clazz, JNI_PROPERTY_ALWAYS_LOAD_CERTIFICATE, JNI_SIGNATURE_PROPERTY_BOOLEAN)
+    INIT_GET_FIELD_ID(id_field, attls_context_clazz, JNI_PROPERTY_ID, JNI_SIGNATURE_PROPERTY_INTEGER)
+    INIT_GET_FIELD_ID(ioctl_field, attls_context_clazz, JNI_PROPERTY_IOCTL, JNI_SIGNATURE_PROPERTY_BYTE_ARRAY)
+    INIT_GET_FIELD_ID(buffer_certificate_field, attls_context_clazz, JNI_PROPERTY_BUFFER_CERTIFICATE, JNI_SIGNATURE_PROPERTY_BYTE_ARRAY)
+    INIT_GET_FIELD_ID(query_loaded_field, attls_context_clazz, JNI_PROPERTY_QUERY_LOADED, JNI_SIGNATURE_PROPERTY_BOOLEAN)
+    INIT_GET_FIELD_ID(certificate_loaded_field, attls_context_clazz, JNI_PROPERTY_CERTIFICATE_LOADED, JNI_SIGNATURE_PROPERTY_BOOLEAN)
+    INIT_GET_FIELD_ID(stat_policy_cache_field, attls_context_clazz, JNI_PROPERTY_STAT_POLICY_CACHE, JNI_SIGNATURE_PROPERTY_STAT_POLICY)
+    INIT_GET_FIELD_ID(stat_conn_cache_field, attls_context_clazz, JNI_PROPERTY_STAT_CONN_CACHE, JNI_SIGNATURE_PROPERTY_STAT_CONN)
+    INIT_GET_FIELD_ID(protocol_cache_field, attls_context_clazz, JNI_PROPERTY_PROTOCOL_CACHE, JNI_SIGNATURE_PROPERTY_PROTOCOL)
+    INIT_GET_FIELD_ID(negotiated_cipher2_cache_field, attls_context_clazz, JNI_PROPERTY_NEGOTIATED_CIPHER_2_CACHE, JNI_SIGNATURE_PROPERTY_STRING)
+    INIT_GET_FIELD_ID(security_type_cache_field, attls_context_clazz, JNI_PROPERTY_SECURITY_TYPE_CACHE, JNI_SIGNATURE_PROPERTY_SECURITY_TYPE)
+    INIT_GET_FIELD_ID(user_id_cache_field, attls_context_clazz, JNI_PROPERTY_USER_ID_CACHE, JNI_SIGNATURE_PROPERTY_STRING)
+    INIT_GET_FIELD_ID(fips140_cache_field, attls_context_clazz, JNI_PROPERTY_FIPS_140_CACHE, JNI_SIGNATURE_PROPERTY_FIPS_140)
+    INIT_GET_FIELD_ID(negotiated_cipher4_cache_field, attls_context_clazz, JNI_PROPERTY_NEGOTIATED_CIPHER_4_CACHE, JNI_SIGNATURE_PROPERTY_STRING)
+    INIT_GET_FIELD_ID(negotiated_key_share_cache_field, attls_context_clazz, JNI_PROPERTY_NEGOTIATED_KEY_SHARE_CACHE, JNI_SIGNATURE_PROPERTY_STRING)
+    INIT_GET_FIELD_ID(certificate_cache_field, attls_context_clazz, JNI_PROPERTY_CERTIFICATE_CACHE, JNI_SIGNATURE_PROPERTY_BYTE_ARRAY)
 
     // prepare EnumMap for all possible relevant enumerations
-    stat_policy_enum_map = load_enum_map(env, JNI_CLASS_STAT_POLICY);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    stat_conn_enum_map = load_enum_map(env, JNI_CLASS_STAT_CONN);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    security_type_enum_map = load_enum_map(env, JNI_CLASS_SECURITY_TYPE);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    fips140_enum_map = load_enum_map(env, JNI_CLASS_FIPS_140);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+    INIT_LOAD_ENUM_MAP(stat_policy_enum_map, JNI_CLASS_STAT_POLICY)
+    INIT_LOAD_ENUM_MAP(stat_conn_enum_map, JNI_CLASS_STAT_CONN)
+    INIT_LOAD_ENUM_MAP(security_type_enum_map, JNI_CLASS_SECURITY_TYPE)
+    INIT_LOAD_ENUM_MAP(fips140_enum_map, JNI_CLASS_FIPS_140)
 
     // fetch Protocol.class and method Protocol.values() - cannot use EnumMap (it has 2 bytes to identify)
-    enum_protocol_clazz = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_CLASS_PROTOCOL));
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    protocol_value_of_method_ID = (*env) -> GetStaticMethodID(env, enum_protocol_clazz, JNI_METHOD_VALUE_OF, JNI_SIGNATURE_METHOD_BYTE_BYTE_PROTOCOL);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+    INIT_FIND_CLASS_REF(enum_protocol_clazz, JNI_CLASS_PROTOCOL)
+    INIT_GET_STATIC_METHOD_ID(protocol_value_of_method_ID, enum_protocol_clazz, JNI_METHOD_VALUE_OF, JNI_SIGNATURE_METHOD_BYTE_BYTE_PROTOCOL);
 
     // find method Arrays.fill for byte array clean up
-    arraysClass = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_SIGNATURE_ARRAYS));
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    arrays_fill_method_ID = (*env) -> GetStaticMethodID(env, arraysClass, JNI_SIGNATURE_ARRAYS_FILL, JNI_SIGNATURE_METHOD_BYTE_ARRAY_BYTE_VOID);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
+    INIT_FIND_CLASS_REF(arraysClass, JNI_SIGNATURE_ARRAYS)
+    INIT_GET_STATIC_METHOD_ID(arrays_fill_method_ID, arraysClass, JNI_SIGNATURE_ARRAYS_FILL, JNI_SIGNATURE_METHOD_BYTE_ARRAY_BYTE_VOID);
 
     // fetch reference to exceptions
-    outOfMemoryErrorClazz = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_CLASS_OUT_OF_MEMORY_ERROR));
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    ioctl_call_exception_clazz = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_CLASS_IOCTL_CALL_EXCEPTION));
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    ioctl_call_exception_constructor = (*env) -> GetMethodID(env, ioctl_call_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_INT_INT_INT_VOID);
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    illegal_argument_exception_clazz = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_CLASS_ILLEGAL_ARGUMENT_EXCEPTION));
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    unknown_enum_value_exception_clazz = (*env) -> NewGlobalRef(env, (*env) -> FindClass(env, JNI_CLASS_UNKNOWN_ENUM_VALUE_EXCEPTION));
-    if ((*env) -> ExceptionCheck(env)) return JNI_VERSION;
-    unknown_enum_value_exception_constructor = (*env) -> GetMethodID(env, unknown_enum_value_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_ENUM_BYTE_BYTE_VOID);
+    INIT_FIND_CLASS_REF(outOfMemoryErrorClazz, JNI_CLASS_OUT_OF_MEMORY_ERROR)
+    INIT_FIND_CLASS_REF(ioctl_call_exception_clazz, JNI_CLASS_IOCTL_CALL_EXCEPTION)
+    INIT_GET_METHOD_ID(ioctl_call_exception_constructor, ioctl_call_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_INT_INT_INT_VOID)
+    INIT_FIND_CLASS_REF(illegal_argument_exception_clazz, JNI_CLASS_ILLEGAL_ARGUMENT_EXCEPTION)
+    INIT_FIND_CLASS_REF(unknown_enum_value_exception_clazz, JNI_CLASS_UNKNOWN_ENUM_VALUE_EXCEPTION)
+    INIT_GET_METHOD_ID(unknown_enum_value_exception_constructor, unknown_enum_value_exception_clazz, JNI_METHOD_CONSTRUCTOR, JNI_SIGNATURE_METHOD_ENUM_BYTE_BYTE_VOID)
 
     return JNI_VERSION;
 }
@@ -514,6 +511,10 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
     jbyteArray ioctlArray = (*env) -> GetObjectField(env, obj, ioctl_field);
     if (!ioctlArray) {
         ioctlArray = (*env) -> NewByteArray(env, sizeof(struct TTLS_IOCTL));
+        if (!ioctlArray) {
+            free(c);
+            return NULL;
+        }
         (*env) -> SetObjectField(env, obj, ioctl_field, ioctlArray);
         emptyIoctlArray = JNI_TRUE;
     }
@@ -533,6 +534,10 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
         jbyteArray certArray = (*env) -> GetObjectField(env, obj, buffer_certificate_field);
         if (!certArray) {
             certArray = (*env) -> NewByteArray(env, buffer_certificate_size);
+            if (!certArray) {
+                free(c);
+                return NULL;
+            }
             (*env) -> SetObjectField(env, obj, buffer_certificate_field, certArray);
             emptyCertificateArray = JNI_TRUE;
         }
@@ -865,8 +870,10 @@ JNIEXPORT jbyteArray JNICALL Java_org_zowe_commons_attls_AttlsContext_getCertifi
     Context* c = requireCertificate(env, obj);
     if (! ((*env) -> ExceptionCheck(env))) {
         out = (*env) -> NewByteArray(env, c -> ioctl_buffer -> TTLSi_Cert_Len);
-        (*env) -> SetByteArrayRegion(env, out, 0, c -> ioctl_buffer -> TTLSi_Cert_Len, c -> ioctl_buffer -> TTLSi_BufferPtr);
-        (*env) -> SetObjectField(env, obj, certificate_cache_field, out);
+        if (out) {
+            (*env) -> SetByteArrayRegion(env, out, 0, c -> ioctl_buffer -> TTLSi_Cert_Len, c -> ioctl_buffer -> TTLSi_BufferPtr);
+            (*env) -> SetObjectField(env, obj, certificate_cache_field, out);
+        }
     }
     releaseContext(env, c);
 


### PR DESCRIPTION
The code contains a couple of minor issues and one serious issue.

The most serious issue is that AT-TLS is caching the buffer values and should not call `ioctl` service for other values. On the first getter call it reads all values and then another getter just reads the value from the buffer. For that, there are two control flags `queryLoaded` and `certificateLoaded`. The bug in there was, that those values were checked but never set. In the end, it was fetched for each getter call. Multiple calls without a certificate worked, but reading a certificate with buffer which contains a result about the certificate allocates more memory and could lead to overloading.

The minor issues are:
- calling delete local references (it could just improve the treatment, but they could be removed automatically after native code evaluation)
- missing `free` call in the initialization (a small amount of memory was allocated all the time - it was not leading to overloading)
- releasing of byte arrays could be called again a different local reference (holding them in the Context object solves potential multiple addressing)
- warning about wrong data type (potential risk during unloading)
- small optimization of code (reduce the amount of calling releasing) - minor refactor