### PR TITLE
fix: AT-TLS second call to obtain certificate

### DIFF
--- a/.github/actions/native-build/action.yml
+++ b/.github/actions/native-build/action.yml
@@ -14,9 +14,18 @@ inputs:
   port:
     description: "SSH Port"
     required: true
+  jdkVersion:
+    description: "JDK version"
+    required: false
+    default: "8"
 runs:
   using: "composite"
   steps:
+    - name: Set up JDK ${{ inputs.jdkVersion }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'semeru'
+        java-version: ${{ inputs.jdkVersion }}
     - name: install zowe/cli
       shell: bash
       run: npm install -g @zowe/cli@6.40.23

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 bin/
 .vscode/
 .gradle/
+zos-utils/.api-dev/
+*.DS_Store
+.api-dev/
+*.jar
+build/

--- a/zos-utils/.gitignore
+++ b/zos-utils/.gitignore
@@ -33,3 +33,5 @@ deploy/scripts/out
 deploy/templates/jcl/out
 deploy/config/local.ts
 node_modules
+
+*.so

--- a/zos-utils/zossrc/AttlsContext.c
+++ b/zos-utils/zossrc/AttlsContext.c
@@ -527,7 +527,7 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
 
     // obtain certificate buffer or create new one if needed
     c -> load_certificate = loadCertificate;
-    if (!c -> load_certificate) {
+    if (!(c -> load_certificate)) {
         c -> load_certificate = (*env) -> GetBooleanField(env, obj, always_load_certificate_field);
     }
     if (c -> load_certificate) {
@@ -545,6 +545,7 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
         c -> certificate_buffer = (*env) -> GetByteArrayElements(env, certArray, 0);
         c -> certificate_buffer_length = buffer_certificate_size;
         c -> ioctl_buffer -> TTLSi_BufferPtr = c -> certificate_buffer;
+        c -> ioctl_buffer -> TTLSi_BufferLen = buffer_certificate_size;
 
         if (erase && !emptyCertificateArray) {
             memset(c -> certificate_buffer, 0, buffer_certificate_size);
@@ -554,6 +555,7 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
         c -> certificate_buffer = NULL;
         c -> certificate_buffer_length = 0;
         c -> ioctl_buffer -> TTLSi_BufferPtr = NULL;
+        c -> ioctl_buffer -> TTLSi_BufferLen = 0;
 
         if (erase) {
             // current call does not require certificate buffer, but it maybe exists. Clean up it for a next call
@@ -870,7 +872,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_zowe_commons_attls_AttlsContext_getCertifi
     if (! ((*env) -> ExceptionCheck(env))) {
         out = (*env) -> NewByteArray(env, c -> ioctl_buffer -> TTLSi_Cert_Len);
         if (out) {
-            (*env) -> SetByteArrayRegion(env, out, 0, c -> certificate_buffer_length, c -> certificate_buffer);
+            (*env) -> SetByteArrayRegion(env, out, 0, c -> ioctl_buffer -> TTLSi_Cert_Len, c -> certificate_buffer);
             (*env) -> SetObjectField(env, obj, certificate_cache_field, out);
         }
     }

--- a/zos-utils/zossrc/AttlsContext.c
+++ b/zos-utils/zossrc/AttlsContext.c
@@ -527,7 +527,7 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
 
     // obtain certificate buffer or create new one if needed
     c -> load_certificate = loadCertificate;
-    if (!loadCertificate) {
+    if (!c -> load_certificate) {
         c -> load_certificate = (*env) -> GetBooleanField(env, obj, always_load_certificate_field);
     }
     if (c -> load_certificate) {
@@ -544,6 +544,7 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
         c -> certificate_array = certArray;
         c -> certificate_buffer = (*env) -> GetByteArrayElements(env, certArray, 0);
         c -> certificate_buffer_length = buffer_certificate_size;
+        c -> ioctl_buffer -> TTLSi_BufferPtr = c -> certificate_buffer;
 
         if (erase && !emptyCertificateArray) {
             memset(c -> certificate_buffer, 0, buffer_certificate_size);
@@ -552,6 +553,7 @@ Context *getContext(JNIEnv *env, jobject obj, jboolean loadCertificate, jboolean
         c -> certificate_array = NULL;
         c -> certificate_buffer = NULL;
         c -> certificate_buffer_length = 0;
+        c -> ioctl_buffer -> TTLSi_BufferPtr = NULL;
 
         if (erase) {
             // current call does not require certificate buffer, but it maybe exists. Clean up it for a next call
@@ -583,7 +585,7 @@ void releaseContext(JNIEnv *env, Context *c)
 }
 
 /**
- * It call ioctl to fetch query or certificate. Query call is done always, the certificate is loaded just if argument
+ * It calls ioctl to fetch query or certificate. Query call is always done, the certificate is loaded only if argument
  * certificate is set to true or alwaysLoadCertificate is set to true.
  * In case of an error during fetching data IoctlCallException is thrown.
  */
@@ -601,9 +603,6 @@ Context* query(JNIEnv *env, jobject obj, jboolean certificate)
     if (c -> load_certificate) {
         c -> ioctl_buffer -> TTLSi_Req_Type |= TTLS_RETURN_CERTIFICATE;
     }
-
-    c -> ioctl_buffer -> TTLSi_BufferPtr = c -> certificate_buffer;
-    c -> ioctl_buffer -> TTLSi_BufferLen = c -> certificate_buffer_length;
 
     // call ioctl
     int rcIoctl = ioctl(c -> socket_id, SIOCTTLSCTL, c -> ioctl_buffer);
@@ -871,7 +870,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_zowe_commons_attls_AttlsContext_getCertifi
     if (! ((*env) -> ExceptionCheck(env))) {
         out = (*env) -> NewByteArray(env, c -> ioctl_buffer -> TTLSi_Cert_Len);
         if (out) {
-            (*env) -> SetByteArrayRegion(env, out, 0, c -> ioctl_buffer -> TTLSi_Cert_Len, c -> ioctl_buffer -> TTLSi_BufferPtr);
+            (*env) -> SetByteArrayRegion(env, out, 0, c -> certificate_buffer_length, c -> certificate_buffer);
             (*env) -> SetObjectField(env, obj, certificate_cache_field, out);
         }
     }

--- a/zos-utils/zossrc/makefile
+++ b/zos-utils/zossrc/makefile
@@ -60,7 +60,7 @@ LIB_ATTLS_31 = "libzowe-attls-31.so"
 LIB_ATTLS_64 = "libzowe-attls.so"
 LIB_USERMAP_64 = "libzowe-usermap.so"
 
-all: $(LIB_USERMAP_64) $(LIB_ATTLS_31) $(LIB_ATTLS_64)
+all: $(LIB_USERMAP_64) $(LIB_ATTLS_64)
 
 install:
 	mkdir -p $(PREFIX)


### PR DESCRIPTION
When the library of AT-TLS was used to read the certificate in another call (ie. first call to check security status and then certificate) the pointer to buffer with the certificate was not obtained well. It could randomly lead to invalid data and certificate was unreadable.

This fix provides a better setting of the pointer and it contains also a couple of cosmetic improvements.

The most important change was to move resetting pointer in IOCTL to `getContext` method because the method `getCertificate` could call just `getContext` and use not updated pointer from IOCTL:
```c
        c -> ioctl_buffer -> TTLSi_BufferPtr = c -> certificate_buffer;
        c -> ioctl_buffer -> TTLSi_BufferLen = buffer_certificate_size;
```

Test scenario:
1. create AttlsContext
2. set allwaysLoadingCertificate to true
3. call any getter except `getCertificate`
4. call `getCertificate`

Expected response:
Method `getCertificate` response with byte array containing only the public key of the client certificate

Wrong response:
The array contains the public part of the client certificate but the first bytes (about 60) are overridden by IOCTL request.